### PR TITLE
migrate to scarb 2.8.2

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/horuslabsio/TBA/blob/main/Scarb.toml"
 license-file = "LICENSE"
 keywords = ["ERC6551", "tokenbound", "cairo", "contracts", "starknet", "standards"]
 readme = "README.md"
-cairo_version = "2.7.0"
+cairo_version = "2.8.2"
 homepage = "https://www.tbaexplorer.com/"
 documentation = "https://github.com/horuslabsio/TBA-SDK"
 
@@ -22,7 +22,7 @@ casm = true
 [lib]
 
 [dependencies]
-starknet = "2.7.0"
+starknet = "2.8.2"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.15.1" }
 
 [dev-dependencies]


### PR DESCRIPTION
- the code compile with warning of some unused import which break the build when i remove them. 